### PR TITLE
Initial codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @carloso2103 @bryantamayo1 @raulanatol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @carloso2103 @bryantamayo1 @raulanatol
+* @carloso2103 @bryantamayo1 @raulanatol @amaryan 


### PR DESCRIPTION
He añadido un fichero CODEOWNERS usado para auto-asignar revisores en los repos.

Faltaría añadir al resto de integrantes del equipo.